### PR TITLE
Missing closing quotes on api_routes example

### DIFF
--- a/contrib/oauth2-proxy.cfg.example
+++ b/contrib/oauth2-proxy.cfg.example
@@ -71,7 +71,7 @@
 
 ## mark paths as API routes to get HTTP Status code 401 instead of redirect to login page
 # api_routes = [
-#   "^/api
+#   "^/api"
 # ]
 
 ## Templates


### PR DESCRIPTION
While parsing config: (28, 4): unescaped control character U+000A

<!--- Provide a general summary of your changes in the Title above -->

`docker compose up -d` fails with:

```
oauth2-proxy  | [2023/05/31 16:52:55] [main.go:43] ERROR: failed to load config: unable to load config file: While parsing config: (28, 4): unescaped control character U+000A
```
When using api_routes example!


## Description

Add missing quotes
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
